### PR TITLE
#30 [영화 상세] 하단 Drag Dismiss 제거

### DIFF
--- a/app/src/main/res/layout/detail_activity.xml
+++ b/app/src/main/res/layout/detail_activity.xml
@@ -17,6 +17,7 @@
         android:transitionGroup="false"
         app:dragDismissDistance="@dimen/drag_dismiss_distance"
         app:dragDismissScale="0.95"
+        app:dragDismissEnableBottomDrag="false"
         tools:context=".ui.detail.DetailActivity">
 
         <!-- Use a separate view for the background, rather than on the root view because it is a

--- a/widget/src/main/java/soup/widget/elastic/ElasticDragDismissFrameLayout.java
+++ b/widget/src/main/java/soup/widget/elastic/ElasticDragDismissFrameLayout.java
@@ -49,6 +49,7 @@ public class ElasticDragDismissFrameLayout extends FrameLayout {
     private float dragDismissScale = 1f;
     private boolean shouldScale = false;
     private float dragElacticity = 0.8f;
+    private boolean enableBottomDrag = false;
 
     // state
     private float totalDrag;
@@ -93,6 +94,9 @@ public class ElasticDragDismissFrameLayout extends FrameLayout {
         if (a.hasValue(R.styleable.ElasticDragDismissFrameLayout_dragElasticity)) {
             dragElacticity = a.getFloat(R.styleable.ElasticDragDismissFrameLayout_dragElasticity,
                     dragElacticity);
+        }
+        if (a.hasValue(R.styleable.ElasticDragDismissFrameLayout_dragDismissEnableBottomDrag)) {
+            enableBottomDrag = a.getBoolean(R.styleable.ElasticDragDismissFrameLayout_dragDismissEnableBottomDrag, true);
         }
         a.recycle();
     }
@@ -196,8 +200,10 @@ public class ElasticDragDismissFrameLayout extends FrameLayout {
 
     private void dragScale(int scroll) {
         if (scroll == 0) return;
-
-        totalDrag += scroll;
+        boolean draggingUp = enableBottomDrag && this.draggingUp;
+        if (draggingUp || scroll < 0) {
+            totalDrag += scroll;
+        }
 
         // track the direction & set the pivot point for scaling
         // don't double track i.e. if start dragging down and then reverse, keep tracking as

--- a/widget/src/main/res/values/attrs_elastic_drag_dismiss_frame_layout.xml
+++ b/widget/src/main/res/values/attrs_elastic_drag_dismiss_frame_layout.xml
@@ -19,6 +19,7 @@
         <attr name="dragDismissFraction" format="float" />
         <attr name="dragDismissScale" format="float" />
         <attr name="dragElasticity" format="float" />
+        <attr name="dragDismissEnableBottomDrag" format="boolean" />
     </declare-styleable>
 
 </resources>


### PR DESCRIPTION
- close #30 
- 지인 요청사항
- 영화 상세화면에서 하단의 Drag Dismiss 기능을 제거한다.
- Refer to [Commit451/ElasticDragDismissLayout](https://github.com/Commit451/ElasticDragDismissLayout/blob/master/elasticdragdismisslayout/src/main/java/com/commit451/elasticdragdismisslayout/ElasticDragDismissDelegate.java#L118)