### PR TITLE
Add colorOnPrimary attribute to reduce color declarations in compose

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -4,6 +4,7 @@
     <style name="Theme.Moop" parent="Base.Theme.Moop">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="colorOnPrimary">@color/colorOnPrimary</item>
         <item name="colorSecondary">@color/colorSecondary</item>
         <item name="colorOnSecondary">@color/colorOnSecondary</item>
         <item name="colorDivider">@color/colorDivider</item>

--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,13 @@ subprojects {
             licenseHeaderFile rootProject.file('spotless/copyright.kt')
         }
     }
+    afterEvaluate {
+        tasks.find {
+            it.name.contains("preBuild")
+        }.each {
+            it.dependsOn spotlessApply
+        }
+    }
 }
 
 Object propOrDef(String propertyName, Object defaultValue) {

--- a/core/src/main/res/values-night/theme_colors.xml
+++ b/core/src/main/res/values-night/theme_colors.xml
@@ -3,6 +3,7 @@
 
     <color name="colorPrimary">@color/black</color>
     <color name="colorPrimaryDark">@color/black</color>
+    <color name="colorOnPrimary">@color/white</color>
     <color name="colorSecondary">#8EB5F0</color>
     <color name="colorOnSecondary">@color/black</color>
     <color name="colorDivider">@color/grey_900</color>

--- a/core/src/main/res/values/theme_colors.xml
+++ b/core/src/main/res/values/theme_colors.xml
@@ -3,6 +3,7 @@
 
     <color name="colorPrimary">@color/white</color>
     <color name="colorPrimaryDark">@color/grey</color>
+    <color name="colorOnPrimary">@color/black</color>
     <color name="colorSecondary">#2D7AF6</color>
     <color name="colorOnSecondary">@color/white</color>
     <color name="colorDivider">@color/grey_100</color>

--- a/feature/theatermap/src/main/java/soup/movie/theatermap/internal/TheaterMapScreen.kt
+++ b/feature/theatermap/src/main/java/soup/movie/theatermap/internal/TheaterMapScreen.kt
@@ -136,7 +136,7 @@ internal fun TheaterMapScreen(
                 BottomSheetScaffold(
                     scaffoldState = bottomSheetScaffoldState,
                     sheetPeekHeight = 0.dp,
-                    sheetElevation = 16.dp,
+                    sheetElevation = if (MaterialTheme.colors.isLight) 16.dp else 0.dp,
                     sheetContent = {
                         TheaterMapFooter(
                             selectedTheater = selectedTheater,
@@ -250,7 +250,6 @@ private fun TheaterMapFooter(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
             .requiredHeight(100.dp)
-            .background(color = MaterialTheme.colors.surface)
             .clickable { onClick() },
     ) {
         val context = LocalContext.current
@@ -263,7 +262,6 @@ private fun TheaterMapFooter(
                 modifier = Modifier
                     .weight(1f)
                     .padding(start = 16.dp, end = 8.dp),
-                color = MaterialTheme.colors.onSurface,
                 fontSize = 15.sp,
                 fontWeight = FontWeight.Bold,
                 maxLines = 1,
@@ -332,8 +330,7 @@ private fun InfoButton(
     ) {
         Icon(
             Icons.Rounded.Info,
-            contentDescription = null,
-            tint = MaterialTheme.colors.onSurface,
+            contentDescription = null
         )
     }
 }
@@ -390,17 +387,11 @@ private fun Toolbar(text: String, onNavigationOnClick: () -> Unit) {
             IconButton(onClick = onNavigationOnClick) {
                 Icon(
                     Icons.Outlined.Menu,
-                    contentDescription = null,
-                    tint = MaterialTheme.colors.onBackground,
+                    contentDescription = null
                 )
             }
         },
-        title = {
-            Text(
-                text = text,
-                color = MaterialTheme.colors.onBackground,
-            )
-        }
+        title = { Text(text = text) }
     )
 }
 

--- a/feature/theme/build.gradle
+++ b/feature/theme/build.gradle
@@ -29,7 +29,6 @@ dependencies {
     implementation Libs.Compose.foundation
     implementation Libs.Compose.material
     implementation Libs.Compose.ui
-    implementation Libs.Compose.runtime_livedata
     implementation Libs.Accompanist.insets
 
     implementation Libs.AndroidX.Navigation.fragment

--- a/feature/theme/src/main/java/soup/movie/theme/ThemeOptionManager.kt
+++ b/feature/theme/src/main/java/soup/movie/theme/ThemeOptionManager.kt
@@ -22,11 +22,12 @@ class ThemeOptionManager(
     private val store: ThemeOptionStore
 ) {
 
-    private val defaultThemeOption: ThemeOption = if (isAtLeastQ()) {
-        ThemeOption.System
-    } else {
-        ThemeOption.Battery
-    }
+    private val defaultThemeOption: ThemeOption =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            ThemeOption.System
+        } else {
+            ThemeOption.Battery
+        }
 
     private val options: List<ThemeOption> = listOf(
         ThemeOption.Light,
@@ -75,10 +76,6 @@ class ThemeOptionManager(
             ThemeOption.System -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
             ThemeOption.Battery -> AppCompatDelegate.MODE_NIGHT_AUTO_BATTERY
         }
-    }
-
-    private fun isAtLeastQ(): Boolean {
-        return Build.VERSION.SDK_INT >= 29
     }
 
     companion object {

--- a/feature/theme/src/main/java/soup/movie/theme/ThemeSettingFragment.kt
+++ b/feature/theme/src/main/java/soup/movie/theme/ThemeSettingFragment.kt
@@ -19,33 +19,12 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Scaffold
-import androidx.compose.material.Text
-import androidx.compose.material.TopAppBar
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import com.google.accompanist.insets.ProvideWindowInsets
-import com.google.accompanist.insets.navigationBarsPadding
-import com.google.accompanist.insets.statusBarsPadding
 import com.google.android.material.composethemeadapter.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
-import soup.movie.util.debounce
+import soup.movie.theme.internal.ThemeOptionScreen
 
 @AndroidEntryPoint
 class ThemeSettingFragment : Fragment() {
@@ -60,76 +39,9 @@ class ThemeSettingFragment : Fragment() {
         return ComposeView(requireContext()).apply {
             setContent {
                 MdcTheme {
-                    ThemeOptionScreen()
+                    ThemeOptionScreen(viewModel)
                 }
             }
-        }
-    }
-
-    @Composable
-    private fun ThemeOptionScreen() {
-        ProvideWindowInsets {
-            val items = viewModel.items.observeAsState(emptyList())
-            Scaffold(
-                modifier = Modifier
-                    .statusBarsPadding()
-                    .navigationBarsPadding(start = false, end = false),
-                topBar = {
-                    TopAppBar(
-                        title = {
-                            Text(
-                                stringResource(R.string.theme_option_title),
-                                color = MaterialTheme.colors.onBackground,
-                            )
-                        }
-                    )
-                }
-            ) { paddingValues ->
-                ThemeOptionList(
-                    items = items.value,
-                    onItemClick = viewModel::onItemClick,
-                    modifier = Modifier.padding(paddingValues)
-                )
-            }
-        }
-    }
-
-    @Composable
-    private fun ThemeOptionList(
-        items: List<ThemeSettingItemUiModel>,
-        onItemClick: (ThemeSettingItemUiModel) -> Unit,
-        modifier: Modifier = Modifier,
-    ) {
-        Column(
-            modifier = modifier
-                .padding(8.dp)
-                .verticalScroll(rememberScrollState())
-        ) {
-            items.forEach {
-                ThemeOptionItem(it, onItemClick)
-            }
-        }
-    }
-
-    @Composable
-    private fun ThemeOptionItem(
-        item: ThemeSettingItemUiModel,
-        onItemClick: (ThemeSettingItemUiModel) -> Unit,
-        modifier: Modifier = Modifier,
-    ) {
-        Column(
-            verticalArrangement = Arrangement.Center,
-            modifier = modifier
-                .fillMaxWidth()
-                .height(60.dp)
-                .clickable { debounce { onItemClick(item) } }
-                .padding(horizontal = 24.dp)
-        ) {
-            Text(
-                text = stringResource(stringResIdOf(item.themeOption)),
-                fontSize = 17.sp,
-                color = MaterialTheme.colors.onBackground,
-            )
         }
     }
 }

--- a/feature/theme/src/main/java/soup/movie/theme/ThemeSettingViewModel.kt
+++ b/feature/theme/src/main/java/soup/movie/theme/ThemeSettingViewModel.kt
@@ -15,8 +15,9 @@
  */
 package soup.movie.theme
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -26,12 +27,11 @@ class ThemeSettingViewModel @Inject constructor(
     private val themeOptionManager: ThemeOptionManager
 ) : ViewModel() {
 
-    private val _items = MutableLiveData<List<ThemeSettingItemUiModel>>()
-    val items: LiveData<List<ThemeSettingItemUiModel>>
-        get() = _items
+    var items by mutableStateOf<List<ThemeSettingItemUiModel>>(emptyList())
+        private set
 
     init {
-        _items.value = themeOptionManager
+        items = themeOptionManager
             .getOptions()
             .map { ThemeSettingItemUiModel(it) }
     }

--- a/feature/theme/src/main/java/soup/movie/theme/internal/ThemeOptionScreen.kt
+++ b/feature/theme/src/main/java/soup/movie/theme/internal/ThemeOptionScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar

--- a/feature/theme/src/main/java/soup/movie/theme/internal/ThemeOptionScreen.kt
+++ b/feature/theme/src/main/java/soup/movie/theme/internal/ThemeOptionScreen.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2021 SOUP
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package soup.movie.theme.internal
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.google.accompanist.insets.ProvideWindowInsets
+import com.google.accompanist.insets.navigationBarsPadding
+import com.google.accompanist.insets.statusBarsPadding
+import soup.movie.theme.R
+import soup.movie.theme.ThemeSettingItemUiModel
+import soup.movie.theme.ThemeSettingViewModel
+import soup.movie.theme.stringResIdOf
+import soup.movie.util.debounce
+
+@Composable
+internal fun ThemeOptionScreen(viewModel: ThemeSettingViewModel) {
+    ProvideWindowInsets {
+        Scaffold(
+            contentColor = MaterialTheme.colors.onSurface,
+            modifier = Modifier
+                .statusBarsPadding()
+                .navigationBarsPadding(start = false, end = false),
+            topBar = {
+                TopAppBar(
+                    title = {
+                        Text(
+                            stringResource(R.string.theme_option_title),
+                            color = MaterialTheme.colors.onBackground,
+                        )
+                    }
+                )
+            }
+        ) { paddingValues ->
+            ThemeOptionList(
+                items = viewModel.items,
+                onItemClick = { viewModel.onItemClick(it) },
+                modifier = Modifier.padding(paddingValues)
+            )
+        }
+    }
+}
+
+@Composable
+private fun ThemeOptionList(
+    items: List<ThemeSettingItemUiModel>,
+    onItemClick: (ThemeSettingItemUiModel) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .padding(8.dp)
+            .verticalScroll(rememberScrollState())
+    ) {
+        items.forEach {
+            ThemeOptionItem(it, onItemClick)
+        }
+    }
+}
+
+@Composable
+private fun ThemeOptionItem(
+    item: ThemeSettingItemUiModel,
+    onItemClick: (ThemeSettingItemUiModel) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        verticalArrangement = Arrangement.Center,
+        modifier = modifier
+            .fillMaxWidth()
+            .height(60.dp)
+            .clickable { debounce { onItemClick(item) } }
+            .padding(horizontal = 24.dp)
+    ) {
+        Text(
+            text = stringResource(stringResIdOf(item.themeOption)),
+            fontSize = 17.sp
+        )
+    }
+}

--- a/feature/theme/src/main/java/soup/movie/theme/internal/ThemeOptionScreen.kt
+++ b/feature/theme/src/main/java/soup/movie/theme/internal/ThemeOptionScreen.kt
@@ -45,19 +45,11 @@ import soup.movie.util.debounce
 internal fun ThemeOptionScreen(viewModel: ThemeSettingViewModel) {
     ProvideWindowInsets {
         Scaffold(
-            contentColor = MaterialTheme.colors.onSurface,
             modifier = Modifier
                 .statusBarsPadding()
                 .navigationBarsPadding(start = false, end = false),
             topBar = {
-                TopAppBar(
-                    title = {
-                        Text(
-                            stringResource(R.string.theme_option_title),
-                            color = MaterialTheme.colors.onBackground,
-                        )
-                    }
-                )
+                TopAppBar(title = { Text(stringResource(R.string.theme_option_title)) })
             }
         ) { paddingValues ->
             ThemeOptionList(

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx3072m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx3072m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configureondemand=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jul 21 23:28:25 KST 2021
+#Mon Sep 13 00:44:03 KST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
ContentColor를 선택할 때,
primary/secondary에서 background/surface와 동일한 색상을 사용하고 있으면
엉뚱한 색상이 선택될 수 있는 구조다.
```kt
fun Colors.contentColorFor(backgroundColor: Color): Color {
    return when (backgroundColor) {
        primary -> onPrimary
        primaryVariant -> onPrimary
        secondary -> onSecondary
        secondaryVariant -> onSecondary
        background -> onBackground
        surface -> onSurface
        error -> onError
        else -> Color.Unspecified
    }
}
```

이를 방지하려면, `Surface`와 연관된 composable을 사용할 때 `contentColor` slot을 항상 설정해줘야 한다.
