### PR TITLE
Update to Google AdMob 23.1.0

### DIFF
--- a/app/dependencies/releaseRuntimeClasspath.txt
+++ b/app/dependencies/releaseRuntimeClasspath.txt
@@ -127,6 +127,7 @@ androidx.vectordrawable:vectordrawable-animated:1.1.0
 androidx.vectordrawable:vectordrawable:1.1.0
 androidx.versionedparcelable:versionedparcelable:1.1.1
 androidx.viewpager:viewpager:1.0.0
+androidx.webkit:webkit:1.11.0
 androidx.window.extensions.core:core:1.0.0
 androidx.window:window:1.3.0
 androidx.work:work-runtime-ktx:2.9.0
@@ -137,10 +138,10 @@ com.google.accompanist:accompanist-permissions:0.34.0
 com.google.android.datatransport:transport-api:3.1.0
 com.google.android.datatransport:transport-backend-cct:3.1.9
 com.google.android.datatransport:transport-runtime:3.1.9
-com.google.android.gms:play-services-ads-base:22.6.0
+com.google.android.gms:play-services-ads-base:23.1.0
 com.google.android.gms:play-services-ads-identifier:18.0.0
-com.google.android.gms:play-services-ads-lite:22.6.0
-com.google.android.gms:play-services-ads:22.6.0
+com.google.android.gms:play-services-ads-lite:23.1.0
+com.google.android.gms:play-services-ads:23.1.0
 com.google.android.gms:play-services-appset:16.0.1
 com.google.android.gms:play-services-base:18.1.0
 com.google.android.gms:play-services-basement:18.3.0
@@ -157,7 +158,7 @@ com.google.android.gms:play-services-tasks:18.1.0
 com.google.android.play:app-update-ktx:2.1.0
 com.google.android.play:app-update:2.1.0
 com.google.android.play:core-common:2.0.3
-com.google.android.ump:user-messaging-platform:2.1.0
+com.google.android.ump:user-messaging-platform:2.2.0
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.dagger:dagger-lint-aar:2.51.1

--- a/app/dependencies/releaseRuntimeClasspath.txt
+++ b/app/dependencies/releaseRuntimeClasspath.txt
@@ -137,10 +137,10 @@ com.google.accompanist:accompanist-permissions:0.34.0
 com.google.android.datatransport:transport-api:3.1.0
 com.google.android.datatransport:transport-backend-cct:3.1.9
 com.google.android.datatransport:transport-runtime:3.1.9
-com.google.android.gms:play-services-ads-base:21.3.0
+com.google.android.gms:play-services-ads-base:21.5.0
 com.google.android.gms:play-services-ads-identifier:18.0.0
-com.google.android.gms:play-services-ads-lite:21.3.0
-com.google.android.gms:play-services-ads:21.3.0
+com.google.android.gms:play-services-ads-lite:21.5.0
+com.google.android.gms:play-services-ads:21.5.0
 com.google.android.gms:play-services-appset:16.0.1
 com.google.android.gms:play-services-base:18.1.0
 com.google.android.gms:play-services-basement:18.3.0

--- a/app/dependencies/releaseRuntimeClasspath.txt
+++ b/app/dependencies/releaseRuntimeClasspath.txt
@@ -137,10 +137,10 @@ com.google.accompanist:accompanist-permissions:0.34.0
 com.google.android.datatransport:transport-api:3.1.0
 com.google.android.datatransport:transport-backend-cct:3.1.9
 com.google.android.datatransport:transport-runtime:3.1.9
-com.google.android.gms:play-services-ads-base:21.5.0
+com.google.android.gms:play-services-ads-base:22.6.0
 com.google.android.gms:play-services-ads-identifier:18.0.0
-com.google.android.gms:play-services-ads-lite:21.5.0
-com.google.android.gms:play-services-ads:21.5.0
+com.google.android.gms:play-services-ads-lite:22.6.0
+com.google.android.gms:play-services-ads:22.6.0
 com.google.android.gms:play-services-appset:16.0.1
 com.google.android.gms:play-services-base:18.1.0
 com.google.android.gms:play-services-basement:18.3.0
@@ -157,7 +157,7 @@ com.google.android.gms:play-services-tasks:18.1.0
 com.google.android.play:app-update-ktx:2.1.0
 com.google.android.play:app-update:2.1.0
 com.google.android.play:core-common:2.0.3
-com.google.android.ump:user-messaging-platform:2.0.0
+com.google.android.ump:user-messaging-platform:2.1.0
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.dagger:dagger-lint-aar:2.51.1

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,6 +31,12 @@
         tools:ignore="GoogleAppIndexingWarning"
         tools:targetApi="tiramisu">
 
+        <!-- https://issuetracker.google.com/issues/327696048 -->
+        <property
+            android:name="android.adservices.AD_SERVICES_CONFIG"
+            android:resource="@xml/gma_ad_services_config"
+            tools:replace="android:resource" />
+
         <profileable
             android:shell="true"
             tools:targetApi="q" />

--- a/core/ads/build.gradle
+++ b/core/ads/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     implementation libs.compose.ui
 
     implementation libs.google.admob
+    implementation libs.androidx.webkit
 
     implementation libs.androidx.constraintlayout
     implementation libs.androidx.lifecycle.runtime

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,13 +27,14 @@ androidx-navigation = "2.8.0-beta02"
 androidx-profileinstaller = "1.3.1"
 androidx-room = "2.6.1"
 androidx-startup = "1.1.1"
+androidx-webkit = "1.11.0"
 androidx-window = "1.3.0"
 androidx-work = "2.9.0"
 
 # Google
 gms = "4.4.1"
 play-appupdate = "2.1.0"
-admob = "22.6.0"
+admob = "23.1.0"
 firebase-bom = "33.0.0"
 firebase-crashlytics = "2.9.9"
 firebase-perf = "1.4.2"
@@ -103,6 +104,7 @@ androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref =
 androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "androidx-room" }
 
 androidx-startup = { module = "androidx.startup:startup-runtime", version.ref = "androidx-startup" }
+androidx-webkit = { module = "androidx.webkit:webkit", version.ref = "androidx-webkit" }
 androidx-window = { module = "androidx.window:window", version.ref = "androidx-window" }
 
 androidx-work-runtime = { module = "androidx.work:work-runtime-ktx", version.ref = "androidx-work" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ androidx-work = "2.9.0"
 # Google
 gms = "4.4.1"
 play-appupdate = "2.1.0"
-admob = "21.5.0"
+admob = "22.6.0"
 firebase-bom = "33.0.0"
 firebase-crashlytics = "2.9.9"
 firebase-perf = "1.4.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ androidx-work = "2.9.0"
 # Google
 gms = "4.4.1"
 play-appupdate = "2.1.0"
-admob = "21.3.0"
+admob = "21.5.0"
 firebase-bom = "33.0.0"
 firebase-crashlytics = "2.9.9"
 firebase-perf = "1.4.2"


### PR DESCRIPTION
- https://developers.google.com/admob/android/rel-notes
- Issues:
   - `AdMob 22.X.X`: Manifest merger failed.
      So I should add the following codes.
      Refer to https://issuetracker.google.com/issues/327696048
      ```xml
      <property
          android:name="android.adservices.AD_SERVICES_CONFIG"
          android:resource="@xml/gma_ad_services_config"
          tools:replace="android:resource" />
      ```
   - `AdMob 23.X.X`: [`androidx.webkit:webkit:1.11.0-alpha02`](https://developer.android.com/jetpack/androidx/releases/webkit#1.11.0-alpha02) added.